### PR TITLE
Sync closed tasks .yml file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Cross off linked issues
+on:
+  # the closed event type causes unchecked checkbox references to be checked / marked complete
+  # the reopened event type causes checked checkbox references to be unchecked / marked incomplete
+  issues:
+    types: [closed, reopened]
+
+  # the action works on pull request events as well
+  pull_request:
+    types: [closed, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cross off any linked issue and PR references
+        uses: jonabc/sync-task-issues@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### YAML FILE
For GitHub action: [Sync closed task references](https://github.com/marketplace/actions/sync-closed-task-references)

### PREMISE:
The current syncing of tasks is a GitHub beta feature (I thought it was already implemented), this will mark tasks as closed when a PR closes issues those tasks reference